### PR TITLE
Add column to items table

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@
 |shipping_method|integer|null:false|
 |size|string||
 |text|text|null:false|
-|seller_id|references|foreign_key|
-|buyer_id|references|foreign_key|
+|brand_id|references|null:false, foreign_key|
+|category_id|references|null:false, foreign_key|
 
 ## Association
 - belongs_to:user

--- a/db/migrate/20190219140313_add_items_to_brands.rb
+++ b/db/migrate/20190219140313_add_items_to_brands.rb
@@ -1,0 +1,6 @@
+class AddItemsToBrands < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :items, :brand, null:false, foreign_key: true
+    add_reference :items, :category, null:false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190209060922) do
+ActiveRecord::Schema.define(version: 20190219140313) do
+
+  create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "postcode",                    null: false
+    t.string  "prefectures",                 null: false
+    t.string  "municipality",                null: false
+    t.string  "street_number",               null: false
+    t.string  "building_name"
+    t.integer "room_number"
+    t.text    "remarks",       limit: 65535
+    t.integer "user_id",                     null: false
+    t.index ["user_id"], name: "index_addresses_on_user_id", using: :btree
+  end
 
   create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string  "name"
@@ -39,7 +51,11 @@ ActiveRecord::Schema.define(version: 20190209060922) do
     t.datetime "updated_at",                    null: false
     t.integer  "seller_id",                     null: false
     t.integer  "buyer_id"
+    t.integer  "brand_id",                      null: false
+    t.integer  "category_id",                   null: false
+    t.index ["brand_id"], name: "index_items_on_brand_id", using: :btree
     t.index ["buyer_id"], name: "index_items_on_buyer_id", using: :btree
+    t.index ["category_id"], name: "index_items_on_category_id", using: :btree
     t.index ["seller_id"], name: "index_items_on_seller_id", using: :btree
     t.index ["user_id"], name: "index_items_on_user_id", using: :btree
   end
@@ -69,6 +85,9 @@ ActiveRecord::Schema.define(version: 20190209060922) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "addresses", "users"
   add_foreign_key "brands", "items"
+  add_foreign_key "items", "brands"
+  add_foreign_key "items", "categories"
   add_foreign_key "items", "users"
 end


### PR DESCRIPTION
## what
商品一覧表示に伴う、DB設計の見直し
## why
メルカリのトップページで商品を一覧表示する際に、itemモデルとbrandモデル、itemモデルとcategoryモデルは1対多の関係でmodelファイルにはアソシエーションの記述があるが、DBにはそれに対応する外部キーがなかった。そのための見直し

## 変更点
itemsテーブルにbrand_idカラムとcategory_idカラムを追加