### PR TITLE
Fix mypege

### DIFF
--- a/app/assets/stylesheets/modules/default/_default-header.scss
+++ b/app/assets/stylesheets/modules/default/_default-header.scss
@@ -1,5 +1,4 @@
 .pc-header {
-  width: 1440px;
   padding: 8px 0 0;
   background: #fff;
 

--- a/app/assets/stylesheets/modules/users/_show.scss
+++ b/app/assets/stylesheets/modules/users/_show.scss
@@ -4,3 +4,4 @@
   background-color: #f5f5f5;
 }
 @import "./modules/users/show/show-mypage-main";
+@import "./modules/default/footer-sell-btn";

--- a/app/assets/stylesheets/modules/users/show/_mypage-side.scss
+++ b/app/assets/stylesheets/modules/users/show/_mypage-side.scss
@@ -35,7 +35,7 @@
   &__mypage-nav__list__item {
     position: relative;
     display: block;
-    padding: 12px 16px;
+    padding: 16px;
     background: #fff;
     color: #333;
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -3,3 +3,4 @@
   = render partial: "users/show/bread-crumbs"
   = render partial: "users/show/show-mypage-main"
   = render partial: "/default/default-footer"
+  = render "default/footer-sell-btn"

--- a/app/views/users/show/_mypage-content.html.haml
+++ b/app/views/users/show/_mypage-content.html.haml
@@ -3,7 +3,7 @@
     = link_to "https://www.mercari.com/jp/mypage/" do
       %figure
         = image_tag "member_photo.png", size: "60x60"
-      %h2.bold 織戸健太郎
+      %h2.bold #{current_user.nickname} 様
       .mypage-user-icon__mypage-number
         %div
           評価


### PR DESCRIPTION
# what
マイページ描写に関わるビューファイルの記述を変更
# why
UX向上のため
# 概要
- マイページを描写した際、ユーザーのニックネームが表示されるようになった
- マイページのサイドバーの高さを調整（本家と同様に）
- 検索フォームを含んだheaderが、一定以上の解像度で開くとレイアウトが崩れる問題を解消
- マイページを開くと出品ボタンが出るようした